### PR TITLE
feature: Use new github release action

### DIFF
--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -10,11 +10,8 @@ on:
     tags:
       - 'v*.*.*'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     steps:
@@ -44,15 +41,6 @@ jobs:
           version: latest
           install: true
           use: true
-
-      # - name: Create Buildx Builder
-      #   run: docker buildx create --name multiarch --driver docker-container --use
-        
-      # - name: Check builder
-      #   run: docker buildx inspect --bootstrap
- 
-      # - name: Publish Multi Platform Image
-      #   run: docker buildx build --push --platform linux/arm64,linux/amd64 --tag evanbuss/openbooks:latest .
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Publish Release Binaries
+name: Create New Release and Upload Binaries
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"
@@ -15,81 +16,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
       - uses: actions/setup-go@v2
         with:
-          stable: false
-          go-version: "^1.16.0-rc1"
+          go-version: "^1.17.0"
       - run: go version
-
-      - name: Use LTS Node.js
-        uses: actions/setup-node@v1
+    
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Build
         run: ./build.sh
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
-
-      - name: Upload Mac Build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/openbooks_mac
-          asset_name: openbooks_mac
-          asset_content_type: application/octet-stream
-
-      - name: Upload Mac ARM Build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/openbooks_mac_arm
-          asset_name: openbooks_mac_arm
-          asset_content_type: application/octet-stream
-
-      - name: Upload Windows Build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/openbooks.exe
-          asset_name: openbooks.exe
-          asset_content_type: application/octet-stream
-
-      - name: Upload Linux AMD64 Build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/openbooks_linux
-          asset_name: openbooks_linux
-          asset_content_type: application/octet-stream
-
-      - name: Upload Linux ARM Build
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/openbooks_linux_arm
-          asset_name: openbooks_linux_arm
-          asset_content_type: application/octet-stream
+          fail_on_unmatched_files: true
+          name: Release ${{ github.ref }}
+          files: |
+            ./build/*


### PR DESCRIPTION
- Simplify the GitHub release action by using a more advanced GitHub action that allows uploading multiple files in a single step.
- The release will only be created if a tag is pushed, otherwise it will just build the binaries and finish.
- Also removed unnecessary comments from the docker publish action.

Closes #32