### PR TITLE
Allow hosting OpenBooks server at a subpath.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 **/node_modules/
 **/build/
+**/dist/
+**/github/
 openbooks.exe
+openbooks
 *.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ COPY --from=build /go/src/openbooks .
 
 EXPOSE 80
 VOLUME [ "/books" ]
+ENV BASE_PATH=/
 
 ENTRYPOINT ["./openbooks", "server", "--dir", "/books", "--port", "80"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Openbooks allows you to download ebooks from irc.irchighway.net quickly and easi
 - Config to perist all eBook files to disk
   - `docker run -p 8080:80 -v /home/evan/Downloads/books:/books evanbuss/openbooks --persist`
 
+### Setting the Base Path
+
+OpenBooks server doesn't have to be hosted at the root of your webserver. The basepath value allows you to host it behind a reverse proxy. The base path value must have opening and closing forward slashes (default "/").
+
+- Docker
+  - `docker run -p 8080:80 -e BASE_PATH=/openbooks/ evanbuss/openbooks`
+- Binary
+  - `./openbooks server --basepath /openbooks/`
+
 ## Development
 
 ### Install the dependencies

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -22,9 +22,9 @@ func init() {
 	serverCmd.Flags().StringP("port", "p", "5228", "Set the local network port for browser mode.")
 	serverCmd.Flags().StringP("dir", "d", os.TempDir(), "The directory where eBooks are saved when persist enabled.")
 	serverCmd.Flags().Bool("persist", false, "Persist eBooks in 'dir'. Default is to delete after sending.")
+	serverCmd.Flags().String("basepath", "/", `Base path where the application is accessible. For example "/openbooks/".`)
 }
 
-// TODO: Something is broken with this new setup...
 var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Run OpenBooks in server mode.",
@@ -36,6 +36,15 @@ var serverCmd = &cobra.Command{
 		port, _ := cmd.Flags().GetString("port")
 		dir, _ := cmd.Flags().GetString("dir")
 		persist, _ := cmd.Flags().GetBool("persist")
+		basepath, _ := cmd.Flags().GetString("basepath")
+
+		// If cli flag isn't set (default value) check for the presence of an
+		// environment variable and use it if found.
+		if basepath == cmd.Flag("basepath").DefValue {
+			if envPath, present := os.LookupEnv("BASE_PATH"); present {
+				basepath = envPath
+			}
+		}
 
 		config := server.Config{
 			Log:         log,
@@ -44,6 +53,7 @@ var serverCmd = &cobra.Command{
 			Port:        port,
 			DownloadDir: dir,
 			Persist:     persist,
+			Basepath:    basepath,
 		}
 
 		server.Start(config)

--- a/docker.md
+++ b/docker.md
@@ -16,6 +16,10 @@
 
 `docker run -d -p 8080:80 evanbuss/openbooks --name my_irc_name`
 
+### Host at a sub path behind a reverse proxy
+
+`docker run -d -p 8080:80 -e BASE_PATH=/openbooks/ evanbuss/openbooks`
+
 ## Arguments
 
 ```
@@ -38,6 +42,8 @@ services:
         restart: unless-stopped
         container_name: OpenBooks
         command: --persist
+        environment:
+          - BASE_PATH=/openbooks/
         image: evan-buss/openbooks:latest
 
 volumes:

--- a/server/app/package-lock.json
+++ b/server/app/package-lock.json
@@ -20,8 +20,8 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.172",
-        "@types/node": "^16.6.2",
-        "@types/react": "^17.0.18",
+        "@types/node": "^16.7.1",
+        "@types/react": "^17.0.19",
         "@types/react-dom": "^17.0.9",
         "@types/styled-components": "^5.1.12",
         "@vitejs/plugin-react-refresh": "^1.3.6",
@@ -488,9 +488,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -499,9 +499,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.18.tgz",
-      "integrity": "sha512-YTLgu7oS5zvSqq49X5Iue5oAbVGhgPc5Au29SJC4VeE17V6gASoOxVkUDy9pXFMRFxCWCD9fLeweNFizo3UzOg==",
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
+      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1905,9 +1905,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "@types/prop-types": {
@@ -1916,9 +1916,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.18.tgz",
-      "integrity": "sha512-YTLgu7oS5zvSqq49X5Iue5oAbVGhgPc5Au29SJC4VeE17V6gASoOxVkUDy9pXFMRFxCWCD9fLeweNFizo3UzOg==",
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
+      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/server/app/package.json
+++ b/server/app/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.172",
-    "@types/node": "^16.6.2",
-    "@types/react": "^17.0.18",
+    "@types/node": "^16.7.1",
+    "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",
     "@types/styled-components": "^5.1.12",
     "@vitejs/plugin-react-refresh": "^1.3.6",

--- a/server/app/src/state/store.ts
+++ b/server/app/src/state/store.ts
@@ -6,9 +6,12 @@ import serverReducer from "./serverSlice";
 import stateReducer from "./stateSlice";
 import { enableMapSet } from "immer";
 
-const wsProtocol = window.location.protocol === "https:" ? "wss://" : "ws://";
-const wsHost = import.meta.env.DEV ? "localhost:5228" : window.location.host;
-const wsUrl = `${wsProtocol}${wsHost}/ws`;
+const websocketURL = new URL(window.location.href + "ws")
+if (websocketURL.protocol.startsWith("https")) {
+    websocketURL.protocol = websocketURL.protocol.replace("https", "wss");
+} else {
+    websocketURL.protocol = websocketURL.protocol.replace("http", "ws");
+}
 
 enableMapSet();
 
@@ -18,7 +21,7 @@ export const store = configureStore({
         history: historyReducer,
         servers: serverReducer
     },
-    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(websocketConn(wsUrl))
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(websocketConn(websocketURL.href))
 });
 
 const saveState = (key: string, state: any): void => {

--- a/server/app/vite.config.ts
+++ b/server/app/vite.config.ts
@@ -3,5 +3,6 @@ import reactRefresh from '@vitejs/plugin-react-refresh'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [reactRefresh()]
+  plugins: [reactRefresh()],
+  base: "./"
 })

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"log"
+	"net/http"
+	"path"
+)
+
+//go:embed app/dist
+var reactClient embed.FS
+
+func registerRoutes(hub *Hub) {
+	basePath := getBaseRoute()
+	fmt.Printf("Base Path %s\n", basePath)
+
+	http.Handle(basePath, serveStaticFiles(basePath, "app/dist"))
+
+	http.HandleFunc(path.Join(basePath, "ws"), func(w http.ResponseWriter, r *http.Request) {
+		serveWs(hub, w, r)
+	})
+
+	http.HandleFunc(path.Join(basePath, "connections"), func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "There are currently %d active connections.", *numConnections)
+	})
+}
+
+func serveStaticFiles(basePath, assetPath string) http.Handler {
+	// update the embedded file system's tree so that index.html is at the root
+	app, err := fs.Sub(reactClient, assetPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// strip the predefined base path and serve the static file
+	return http.StripPrefix(basePath, http.FileServer(http.FS(app)))
+}
+
+func getBaseRoute() string {
+	cleaned := path.Clean(config.Basepath)
+	if cleaned == "/" {
+		return cleaned
+	}
+	return cleaned + "/"
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -14,7 +14,7 @@ var reactClient embed.FS
 
 func registerRoutes(hub *Hub) {
 	basePath := getBaseRoute()
-	fmt.Printf("Base Path %s\n", basePath)
+	fmt.Printf("Base Path: %s\n", basePath)
 
 	http.Handle(basePath, serveStaticFiles(basePath, "app/dist"))
 

--- a/todo
+++ b/todo
@@ -8,3 +8,5 @@
     - Format - Find unique formats and have clickable options
 - Use new Pulsar component instead of custom version
 - Make the "connected" indicator actually work...
+- Show IRC name in web interface
+- Show raw IRC logs in web interface


### PR DESCRIPTION
- The base path is set via environment variable or CLI argument
- Update the GitHub and DockerHub readme files to explain its usage.
- Removed the `AddPrefix()` function in favor of the built-in `fs.Sub()` which I didn't know about before.

How it works:
- The API routes are adjusted to the base path the user chooses.
- The web socket connection logic is updated to use the path the React SPA is being hosted at.

See #26
