### PR TITLE
Replace various "path" module calls with "filepath" module calls.

### DIFF
--- a/cmd/openbooks/server.go
+++ b/cmd/openbooks/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/evan-buss/openbooks/server"
 
@@ -16,7 +17,7 @@ func init() {
 	serverCmd.Flags().BoolP("browser", "b", false, "Open the browser on server start.")
 	serverCmd.Flags().StringP("name", "n", generateUserName(), "Use a name that isn't randomly generated. One word only.")
 	serverCmd.Flags().StringP("port", "p", "5228", "Set the local network port for browser mode.")
-	serverCmd.Flags().StringP("dir", "d", path.Join(os.TempDir(), "openbooks"), "The directory where eBooks are saved when persist enabled.")
+	serverCmd.Flags().StringP("dir", "d", filepath.Join(os.TempDir(), "openbooks"), "The directory where eBooks are saved when persist enabled.")
 	serverCmd.Flags().Bool("persist", false, "Persist eBooks in 'dir'. Default is to delete after sending.")
 	serverCmd.Flags().String("basepath", "/", `Base path where the application is accessible. For example "/openbooks/".`)
 	serverCmd.Flags().StringP("server", "s", "irc.irchighway.net", "IRC server to connect to.")

--- a/server/irc_events.go
+++ b/server/irc_events.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/evan-buss/openbooks/core"
 )
@@ -23,7 +24,7 @@ func (server *server) NewIrcEventHandler(client *Client) core.EventHandler {
 // searchResultHandler downloads from DCC server, parses data, and sends data to client
 func (c *Client) searchResultHandler(downloadDir string) core.HandlerFunc {
 	return func(text string) {
-		extractedPath, err := core.DownloadExtractDCCString(path.Join(downloadDir, "books"), text, nil)
+		extractedPath, err := core.DownloadExtractDCCString(filepath.Join(downloadDir, "books"), text, nil)
 		if err != nil {
 			c.log.Println(err)
 		}
@@ -59,7 +60,7 @@ func (c *Client) searchResultHandler(downloadDir string) core.HandlerFunc {
 // bookResultHandler downloads the book file and sends it over the websocket
 func (c *Client) bookResultHandler(downloadDir string) core.HandlerFunc {
 	return func(text string) {
-		extractedPath, err := core.DownloadExtractDCCString(path.Join(downloadDir, "books"), text, nil)
+		extractedPath, err := core.DownloadExtractDCCString(filepath.Join(downloadDir, "books"), text, nil)
 		if err != nil {
 			c.log.Println(err)
 			c.send <- ErrorResponse{
@@ -69,7 +70,7 @@ func (c *Client) bookResultHandler(downloadDir string) core.HandlerFunc {
 			return
 		}
 
-		fileName := path.Base(extractedPath)
+		fileName := filepath.Base(extractedPath)
 
 		c.log.Printf("Sending book entitled '%s'.\n", fileName)
 		c.send <- DownloadResponse{

--- a/server/routes.go
+++ b/server/routes.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/evan-buss/openbooks/irc"
@@ -144,7 +145,7 @@ func (server *server) getAllBooksHandler() http.HandlerFunc {
 			return
 		}
 
-		libraryDir := path.Join(server.config.DownloadDir, "books")
+		libraryDir := filepath.Join(server.config.DownloadDir, "books")
 		books, err := os.ReadDir(libraryDir)
 		if err != nil {
 			server.log.Printf("Unable to list books. %s\n", err)
@@ -176,7 +177,7 @@ func (server *server) getAllBooksHandler() http.HandlerFunc {
 func (server *server) getBookHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, fileName := path.Split(r.URL.Path)
-		bookPath := path.Join(server.config.DownloadDir, "books", fileName)
+		bookPath := filepath.Join(server.config.DownloadDir, "books", fileName)
 
 		http.ServeFile(w, r, bookPath)
 
@@ -197,7 +198,7 @@ func (server *server) deleteBooksHandler() http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 
-		err = os.Remove(path.Join(server.config.DownloadDir, "books", fileName))
+		err = os.Remove(filepath.Join(server.config.DownloadDir, "books", fileName))
 		if err != nil {
 			server.log.Printf("Error deleting book file: %s\n", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -133,7 +134,7 @@ func (server *server) registerGracefulShutdown(cancel context.CancelFunc) {
 }
 
 func createBooksDirectory(config Config) {
-	err := os.MkdirAll(path.Join(config.DownloadDir, "books"), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Join(config.DownloadDir, "books"), os.FileMode(0755))
 	if err != nil {
 		panic(err)
 	}

--- a/util/logger.go
+++ b/util/logger.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -13,13 +13,13 @@ func CreateLogFile(username, dir string) (*log.Logger, io.Closer, error) {
 	date := time.Now().Format("2006-01-02--15-04-05")
 	fileName := fmt.Sprintf("%s--%s.log", username, date)
 
-	err := os.MkdirAll(path.Join(dir, "logs"), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Join(dir, "logs"), os.FileMode(0755))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	path := path.Join(dir, "logs", fileName)
-	logFile, err := os.Create(path)
+	logPath := filepath.Join(dir, "logs", fileName)
+	logFile, err := os.Create(logPath)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Testing on Windows revealed that I was using the
  wrong module when dealing file paths versus
  URL paths since Windows file paths use the backslash
  instead of the Unix forward slash.