### PR TITLE
Feature/rate limit searches

### DIFF
--- a/cli/interactive.go
+++ b/cli/interactive.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/evan-buss/openbooks/core"
 	"github.com/evan-buss/openbooks/irc"
 )
+
+var lastSearch time.Time
 
 func terminalMenu(irc *irc.Conn) {
 	fmt.Print("\ns)search\ng)et book\nd)one\n~> ")
@@ -24,8 +27,10 @@ func terminalMenu(irc *irc.Conn) {
 	case "s":
 		fmt.Print("@search ")
 		message, _ := reader.ReadString('\n')
-		core.SearchBook(irc, clean(message))
 		fmt.Println("\nSent search request.")
+		time.Sleep(time.Until(lastSearch.Add(time.Second * 15)))
+		core.SearchBook(irc, clean(message))
+		lastSearch = time.Now()
 	case "g":
 		fmt.Print("Download String: ")
 		message, _ := reader.ReadString('\n')

--- a/cli/util.go
+++ b/cli/util.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/evan-buss/openbooks/core"
 	"github.com/evan-buss/openbooks/irc"
@@ -45,4 +48,26 @@ func (config *Config) setupLogger(handler core.EventHandler) io.Closer {
 	}
 
 	return file
+}
+
+func GetLastSearchTime() time.Time {
+	timestampFilePath := filepath.Join(os.TempDir(), ".openbooks")
+	fileInfo, err := os.Stat(timestampFilePath)
+
+	if errors.Is(err, os.ErrNotExist) {
+		return time.Time{}
+	}
+
+	return fileInfo.ModTime()
+}
+
+func SetLastSearchTime() {
+	timestampFilePath := filepath.Join(os.TempDir(), ".openbooks")
+	_, err := os.Stat(timestampFilePath)
+
+	if errors.Is(err, os.ErrNotExist) {
+		os.Create(timestampFilePath)
+	}
+
+	os.Chtimes(timestampFilePath, time.Now(), time.Now())
 }

--- a/cmd/openbooks/cli.go
+++ b/cmd/openbooks/cli.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/evan-buss/openbooks/cli"
 	"github.com/spf13/cobra"
@@ -60,6 +61,9 @@ var searchCmd = &cobra.Command{
 	Short: "Searches for a book and exits.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		nextSearchTime := cli.GetLastSearchTime().Add(15 * time.Second)
+		time.Sleep(time.Until(nextSearchTime))
 		cli.StartSearch(config, args[0])
+		cli.SetLastSearchTime()
 	},
 }

--- a/cmd/openbooks/main.go
+++ b/cmd/openbooks/main.go
@@ -27,5 +27,5 @@ func main() {
 func generateUserName() string {
 	rand.Seed(time.Now().UnixNano())
 	gofakeit.Seed(int64(rand.Int()))
-	return fmt.Sprintf("%s-%s", gofakeit.Adjective(), gofakeit.Noun())
+	return fmt.Sprintf("%s_%s", gofakeit.Adjective(), gofakeit.Noun())
 }

--- a/cmd/openbooks/server.go
+++ b/cmd/openbooks/server.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/evan-buss/openbooks/server"
 
@@ -21,6 +22,7 @@ func init() {
 	serverCmd.Flags().Bool("persist", false, "Persist eBooks in 'dir'. Default is to delete after sending.")
 	serverCmd.Flags().String("basepath", "/", `Base path where the application is accessible. For example "/openbooks/".`)
 	serverCmd.Flags().StringP("server", "s", "irc.irchighway.net", "IRC server to connect to.")
+	serverCmd.Flags().IntP("rate-limit", "r", 10, "The number of seconds to wait between searches to reduce strain on IRC search servers. Minimum is 10 seconds.")
 }
 
 var serverCmd = &cobra.Command{
@@ -36,6 +38,7 @@ var serverCmd = &cobra.Command{
 		persist, _ := cmd.Flags().GetBool("persist")
 		basepath, _ := cmd.Flags().GetString("basepath")
 		url, _ := cmd.Flags().GetString("server")
+		rateLimit, _ := cmd.Flags().GetInt("rate-limit")
 
 		// If cli flag isn't set (default value) check for the presence of an
 		// environment variable and use it if found.
@@ -45,15 +48,21 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
+		// If user enters a limit that's too low, set to default of 10 seconds.
+		if rateLimit < 10 {
+			rateLimit = 10
+		}
+
 		config := server.Config{
-			Log:         log,
-			OpenBrowser: browser,
-			UserName:    name,
-			Port:        port,
-			DownloadDir: dir,
-			Persist:     persist,
-			Basepath:    sanitizePath(basepath),
-			Server:      url,
+			Log:           log,
+			OpenBrowser:   browser,
+			UserName:      name,
+			Port:          port,
+			DownloadDir:   dir,
+			Persist:       persist,
+			Basepath:      sanitizePath(basepath),
+			Server:        url,
+			SearchTimeout: time.Duration(rateLimit) * time.Second,
 		}
 
 		server.Start(config)

--- a/server/app/src/models/messages.ts
+++ b/server/app/src/models/messages.ts
@@ -5,7 +5,8 @@ export enum MessageType {
   DOWNLOAD = 4,
   // SERVERS = 5,
   WAIT = 5,
-  IRCERROR = 6
+  IRCERROR = 6,
+  SEARCHRATELIMIT = 7
 }
 
 export interface BookResponse {

--- a/server/app/src/state/historySlice.ts
+++ b/server/app/src/state/historySlice.ts
@@ -52,8 +52,17 @@ export const historySlice = createSlice({
 
 // Delete an item from history. Clear current item and loading state if deleting active search
 const deleteHistoryItem =
-  (timeStamp: number): AppThunk =>
+  (timeStamp?: number): AppThunk =>
   (dispatch, getStore) => {
+    if (timeStamp === undefined) {
+      dispatch(setActiveItem(null));
+      const toRemove = getStore().history.items.at(0)?.timestamp;
+      if (toRemove) {
+        dispatch(historySlice.actions.deleteByTimetamp(toRemove));
+      }
+      return;
+    }
+
     const activeItem = getStore().state.activeItem;
     if (activeItem?.timestamp === timeStamp) {
       dispatch(setActiveItem(null));

--- a/server/app/src/state/socketMiddleware.ts
+++ b/server/app/src/state/socketMiddleware.ts
@@ -10,6 +10,7 @@ import {
 import { addNotification } from "./notificationSlice";
 import { Notification, NotificationType } from "./models";
 import { openbooksApi } from "./api";
+import { deleteHistoryItem } from "./historySlice";
 
 // Web socket redux middleware.
 // Listens to socket and dispatches handlers.
@@ -100,6 +101,14 @@ const route = (store: Store, msg: MessageEvent<any>): void => {
         return {
           type: NotificationType.DANGER,
           title: "IRC Error. Try again.",
+          timestamp
+        };
+      case MessageType.SEARCHRATELIMIT:
+        store.dispatch(deleteHistoryItem() as unknown as AnyAction);
+        return {
+          type: NotificationType.WARNING,
+          title: "Search Rate Limit",
+          detail: response.status,
           timestamp
         };
       default:

--- a/server/messages.go
+++ b/server/messages.go
@@ -89,7 +89,8 @@ type IrcErrorResponse struct {
 	Status      string `json:"status"`
 }
 
-// IrcErrorResponse is a response that indicates something went wrong on the IRC server's end
+// SearchRateLimitResponse is a response that indicates the user is making search requests to quickly.
+// Displays the time until the next search request can be made.
 type SearchRateLimitResponse struct {
 	MessageType int    `json:"type"`
 	Status      string `json:"status"`

--- a/server/messages.go
+++ b/server/messages.go
@@ -15,6 +15,7 @@ const (
 	DOWNLOAD
 	WAIT
 	IRCERROR
+	SEARCHRATELIMIT
 )
 
 func messageToString(s int) string {
@@ -84,6 +85,12 @@ type WaitResponse struct {
 
 // IrcErrorResponse is a response that indicates something went wrong on the IRC server's end
 type IrcErrorResponse struct {
+	MessageType int    `json:"type"`
+	Status      string `json:"status"`
+}
+
+// IrcErrorResponse is a response that indicates something went wrong on the IRC server's end
+type SearchRateLimitResponse struct {
 	MessageType int    `json:"type"`
 	Status      string `json:"status"`
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -69,7 +69,7 @@ func (server *server) serveWs() http.HandlerFunc {
 		}
 
 		// Each client gets its own connection, so use different usernames by appending count
-		name := fmt.Sprintf("%s-%d", server.config.UserName, len(server.clients)+1)
+		name := fmt.Sprintf("%s_%d", server.config.UserName, len(server.clients)+1)
 		client := &Client{
 			conn: conn,
 			send: make(chan interface{}, 128),

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -35,18 +36,25 @@ type server struct {
 	unregister chan *Client
 
 	log *log.Logger
+
+	// Mutex to guard the lastSearch timestamp
+	lastSearchMutex sync.Mutex
+
+	// The time the last search was performed. Used to rate limit searches.
+	lastSearch time.Time
 }
 
 // Config contains settings for server
 type Config struct {
-	Log         bool
-	OpenBrowser bool
-	Port        string
-	UserName    string
-	Persist     bool
-	DownloadDir string
-	Basepath    string
-	Server      string
+	Log           bool
+	OpenBrowser   bool
+	Port          string
+	UserName      string
+	Persist       bool
+	DownloadDir   string
+	Basepath      string
+	Server        string
+	SearchTimeout time.Duration
 }
 
 func New(config Config) *server {

--- a/server/websocket_requests.go
+++ b/server/websocket_requests.go
@@ -78,11 +78,11 @@ func (c *Client) sendSearchRequest(s *SearchRequest, server *server) {
 	nextAvailableSearch := server.lastSearch.Add(server.config.SearchTimeout)
 
 	if time.Now().Before(nextAvailableSearch) {
-		remaining := time.Until(server.lastSearch.Add(server.config.SearchTimeout))
+		remainingSeconds := time.Until(nextAvailableSearch).Seconds()
 
 		c.send <- SearchRateLimitResponse{
 			MessageType: SEARCHRATELIMIT,
-			Status:      fmt.Sprintf("Please wait %v seconds to submit another search.", math.Round(remaining.Seconds())),
+			Status:      fmt.Sprintf("Please wait %v seconds to submit another search.", math.Round(remainingSeconds)),
 		}
 		return
 	}


### PR DESCRIPTION
- Implement rate limiting for both browser mode and CLI mode.
- The minimum limit is 1 search per 10 seconds but this can be configured for a higher value via the "--rate-limit" flag when launching OpenBooks.

Here's a preview of what the user will see when they try to search too quickly:

![Preview](https://user-images.githubusercontent.com/18509589/147858387-293e6896-e14d-4a2a-8ef4-307b864ef7c8.gif)

