### PR TITLE
Show Results Grid Even When Search Returned Only Error Lines

### DIFF
--- a/core/search_parser.go
+++ b/core/search_parser.go
@@ -160,8 +160,8 @@ func parseLine(line string) (BookDetail, error) {
 }
 
 func ParseSearchV2(reader io.Reader) ([]BookDetail, []ParseError) {
-	var books []BookDetail
-	var parseErrors []ParseError
+	books := make([]BookDetail, 0)
+	parseErrors := make([]ParseError, 0)
 
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/server/app/src/components/ErrorsGrid/ErrorsGrid.tsx
+++ b/server/app/src/components/ErrorsGrid/ErrorsGrid.tsx
@@ -56,7 +56,11 @@ export default function ErrorsGrid({ errors }: Props) {
             )
             .map((book, i) => (
               <Table.Row key={book.line + i} isSelectable>
-                <Table.TextCell flexBasis={250} flexGrow={1} flexShrink={0}>
+                <Table.TextCell
+                  flexBasis={250}
+                  flexGrow={1}
+                  flexShrink={0}
+                  cursor="text">
                   <code>{book.line}</code>
                 </Table.TextCell>
                 <Table.TextCell flexBasis={350} flexGrow={0} flexShrink={0}>

--- a/server/app/src/components/SideBar/SearchHistory.tsx
+++ b/server/app/src/components/SideBar/SearchHistory.tsx
@@ -99,7 +99,7 @@ const HistoryCard: React.FC<Props> = ({ activeTS, item, dispatch }: Props) => {
           textOverflow="ellipsis">
           {item.query}
         </Text>
-        {!item.results?.length ? (
+        {!item.results?.length && !item.errors?.length ? (
           <Spinner size={20} marginRight={5} />
         ) : (
           <Badge color="blue">{`${item.results?.length} RESULTS`}</Badge>

--- a/server/irc_events.go
+++ b/server/irc_events.go
@@ -38,7 +38,7 @@ func (c *Client) searchResultHandler(downloadDir string) core.HandlerFunc {
 			}
 		}
 
-		if len(results) == 0 {
+		if len(results) == 0 && len(errors) == 0 {
 			c.noResultsHandler(text)
 			return
 		}

--- a/todo
+++ b/todo
@@ -7,3 +7,9 @@ Future:
   - Convert grid to use React Grid instead of Evergreen's built in one.
     - Things like styling are more difficult with Evergreen (ex. can't round the bottom corners)
   - Send download progress updates to the browser like we show for the CLI
+  - Improve message formats. 
+    - Don't need as many separate message types. Just have functions that create them with the appropriate status code.
+  - Log the address to access it in the browser on startup
+  - When the results contain only lines that couldn't be parsed,
+    the grid doesn't show and user can't manually download.
+  - Prevent double clicking the download button.


### PR DESCRIPTION
- Instead of showing error, show blank results grid and allow user to click the "Parse Error" button to manually download by copy pasting the raw response line.
- See #55