### PR TITLE
Added usage tutorial for Non-Programmers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Openbooks allows you to download ebooks from irc.irchighway.net quickly and easi
 3. `./openbooks --help`
    - This will display all possible configuration values and introduce the two modes; CLI or Server.
 
+### Usage For Non-Programmers
+1. Download the latest release for your platform from the [releases page](https://github.com/evan-buss/openbooks/releases).
+2. Download [launcher](https://github.com/Oliver81594/openbooks-launcher/releases) for your platform.
+3. Make sure they are in the same folder and double-click the launcher. This will open a website that you can use. To exit the app just close the command line window.
+
 ### Docker
 
 - Basic config


### PR DESCRIPTION
Added a usage tutorial for Non-Programmers
- No changes in code, only in README
- Tutorial provides a launcher stored [here](https://github.com/Oliver81594/openbooks-launcher)
   - Launcher can be moved to your original repository if preferred, but I didn't want to interfere with your folder structure
   - Right now only Windows launcher is available, others may be added later
