### PR TITLE
feat: add --searchbot flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,12 +10,13 @@ import (
 )
 
 type Config struct {
-	UserName string // Username to use when connecting to IRC
-	Log      bool   // True if IRC messages should be logged
-	Dir      string
-	Server   string
-	irc      *irc.Conn
-	Version  string
+	UserName  string // Username to use when connecting to IRC
+	Log       bool   // True if IRC messages should be logged
+	Dir       string
+	Server    string
+	SearchBot string
+	Version   string
+	irc       *irc.Conn
 }
 
 // StartInteractive instantiates the OpenBooks CLI interface
@@ -37,7 +38,7 @@ func StartInteractive(config Config) {
 	}
 
 	go core.StartReader(ctx, config.irc, handler)
-	terminalMenu(config.irc)
+	terminalMenu(config)
 
 	<-ctx.Done()
 }
@@ -93,7 +94,7 @@ func StartSearch(config Config, query string) {
 	time.Sleep(time.Until(nextSearchTime))
 
 	go core.StartReader(ctx, config.irc, handler)
-	core.SearchBook(config.irc, query)
+	core.SearchBook(config.irc, config.SearchBot, query)
 
 	setLastSearchTime()
 	fmt.Printf("%sSent search request.", clearLine)

--- a/cmd/openbooks/cli.go
+++ b/cmd/openbooks/cli.go
@@ -23,16 +23,21 @@ func init() {
 		log.Fatalln("Could not get current working directory.", err)
 	}
 
-	cliConfig.Version = fmt.Sprintf("OpenBooks CLI %s", version)
-	cliCmd.PersistentFlags().StringVarP(&cliConfig.UserName, "name", "n", generateUserName(), "Use a name that isn't randomly generated. One word only.")
-	cliCmd.PersistentFlags().StringVarP(&cliConfig.Dir, "directory", "d", cwd, "Directory where files are downloaded.")
-	cliCmd.PersistentFlags().BoolVarP(&cliConfig.Log, "log", "l", false, "Whether or not to log IRC messages to an output file.")
-	cliCmd.PersistentFlags().StringVarP(&cliConfig.Server, "server", "s", "irc.irchighway.net", "IRC server to connect to.")
+	// Change the default to CWD for CLI mode.
+	cliCmd.InheritedFlags().StringVarP(&cliConfig.Dir, "dir", "d", cwd, "Directory where files are downloaded.")
+	cliCmd.PersistentFlags().StringVarP(&cliConfig.Dir, "dir", "d", cwd, "Directory where files are downloaded.")
 }
 
 var cliCmd = &cobra.Command{
 	Use:   "cli",
-	Short: "Run openbooks from the terminal in CLI mode.",
+	Short: "Run openbooks from the terminal in interactive CLI mode.",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cliConfig.Version = fmt.Sprintf("OpenBooks CLI %s", ircVersion)
+		cliConfig.UserName = globalFlags.UserName
+		cliConfig.Server = globalFlags.Server
+		cliConfig.Log = globalFlags.Log
+		cliConfig.SearchBot = globalFlags.SearchBot
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cli.StartInteractive(cliConfig)
 	},

--- a/cmd/openbooks/main.go
+++ b/cmd/openbooks/main.go
@@ -4,13 +4,40 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v5"
 	"github.com/spf13/cobra"
 )
 
-const version = "4.3.0"
+// version will always match the GitHub release versions.
+var version = "4.4.0"
+
+// We only increment ircVersion when irc admins require a fix to be made.
+// They can block / permit certain version numbers. ircVersion is the current permitted
+// version number.
+const ircVersion = "4.3.0"
+
+type GlobalFlags struct {
+	UserName    string
+	Server      string
+	DownloadDir string
+	Log         bool
+	SearchBot   string
+}
+
+var globalFlags GlobalFlags
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&globalFlags.UserName, "name", "n", generateUserName(), "Use a name that isn't randomly generated. One word only.")
+	rootCmd.PersistentFlags().StringVarP(&globalFlags.Server, "server", "s", "irc.irchighway.net", "IRC server to connect to.")
+	rootCmd.PersistentFlags().StringVarP(&globalFlags.DownloadDir, "dir", "d", filepath.Join(os.TempDir(), "openbooks"), "The directory where eBooks are saved when persist enabled.")
+	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Log, "log", "l", false, "Save raw IRC logs for each client connection.")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.SearchBot, "searchbot", "search", "The IRC bot that handles search queries. Try 'searchook' if 'search' is down.")
+
+	rootCmd.MarkPersistentFlagDirname("dir")
+}
 
 var rootCmd = &cobra.Command{
 	Use:     "openbooks",

--- a/cmd/openbooks/server.go
+++ b/cmd/openbooks/server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/evan-buss/openbooks/server"
@@ -17,15 +16,10 @@ var serverConfig server.Config
 func init() {
 	rootCmd.AddCommand(serverCmd)
 
-	serverConfig.Version = fmt.Sprintf("OpenBooks Server %s", version)
-	serverCmd.Flags().BoolVarP(&serverConfig.Log, "log", "l", false, "Save raw IRC logs for each client connection.")
 	serverCmd.Flags().BoolVarP(&serverConfig.OpenBrowser, "browser", "b", false, "Open the browser on server start.")
-	serverCmd.Flags().StringVarP(&serverConfig.UserName, "name", "n", generateUserName(), "Use a name that isn't randomly generated. One word only.")
 	serverCmd.Flags().StringVarP(&serverConfig.Port, "port", "p", "5228", "Set the local network port for browser mode.")
-	serverCmd.Flags().StringVarP(&serverConfig.DownloadDir, "dir", "d", filepath.Join(os.TempDir(), "openbooks"), "The directory where eBooks are saved when persist enabled.")
 	serverCmd.Flags().BoolVar(&serverConfig.Persist, "persist", false, "Persist eBooks in 'dir'. Default is to delete after sending.")
 	serverCmd.Flags().StringVar(&serverConfig.Basepath, "basepath", "/", `Base path where the application is accessible. For example "/openbooks/".`)
-	serverCmd.Flags().StringVarP(&serverConfig.Server, "server", "s", "irc.irchighway.net", "IRC server to connect to.")
 	serverCmd.Flags().IntP("rate-limit", "r", 10, "The number of seconds to wait between searches to reduce strain on IRC search servers. Minimum is 10 seconds.")
 }
 
@@ -33,6 +27,14 @@ var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Run OpenBooks in server mode.",
 	Long:  "Run OpenBooks in server mode. This allows you to use a web interface to search and download eBooks.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		serverConfig.Version = fmt.Sprintf("OpenBooks Server %s", ircVersion)
+		serverConfig.UserName = globalFlags.UserName
+		serverConfig.DownloadDir = globalFlags.DownloadDir
+		serverConfig.Log = globalFlags.Log
+		serverConfig.Server = globalFlags.Server
+		// serverConfig.SearchBot = globalFlags.SearchBot
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		rateLimit, _ := cmd.Flags().GetInt("rate-limit")
 

--- a/core/irchighway.go
+++ b/core/irchighway.go
@@ -24,8 +24,9 @@ func Join(irc *irc.Conn, url string) error {
 }
 
 // SearchBook sends a search query to the search bot
-func SearchBook(irc *irc.Conn, query string) {
-	irc.SendMessage("@search " + query)
+func SearchBook(irc *irc.Conn, searchBot string, query string) {
+	searchBot = strings.TrimPrefix(searchBot, "@")
+	irc.SendMessage(fmt.Sprintf("@%s %s", searchBot, query))
 }
 
 // DownloadBook sends the book string to the download bot

--- a/server/server.go
+++ b/server/server.go
@@ -55,6 +55,7 @@ type Config struct {
 	Basepath      string
 	Server        string
 	SearchTimeout time.Duration
+	SearchBot     string
 	Version       string
 }
 

--- a/server/websocket_requests.go
+++ b/server/websocket_requests.go
@@ -93,7 +93,7 @@ func (c *Client) sendSearchRequest(s *SearchRequest, server *server) {
 		return
 	}
 
-	core.SearchBook(c.irc, s.Query)
+	core.SearchBook(c.irc, server.config.SearchBot, s.Query)
 	server.lastSearch = time.Now()
 
 	c.send <- newStatusResponse(NOTIFY, "Search request sent.")


### PR DESCRIPTION
Allows users to modify the search bot that is used on the irc channel. Sometimes a specific search bot is down.

Example Use:
```
./openbooks server --searchbot searchook
```