### PR TITLE
feat: add flag to disable automatic browser downloads

### DIFF
--- a/cmd/openbooks/server.go
+++ b/cmd/openbooks/server.go
@@ -21,6 +21,7 @@ func init() {
 	serverCmd.Flags().BoolVar(&serverConfig.Persist, "persist", false, "Persist eBooks in 'dir'. Default is to delete after sending.")
 	serverCmd.Flags().StringVar(&serverConfig.Basepath, "basepath", "/", `Base path where the application is accessible. For example "/openbooks/".`)
 	serverCmd.Flags().IntP("rate-limit", "r", 10, "The number of seconds to wait between searches to reduce strain on IRC search servers. Minimum is 10 seconds.")
+	serverCmd.Flags().BoolVar(&serverConfig.DisableBrowserDownloads, "no-browser-downloads", false, "The browser won't recieve and download eBook files, but they are still saved to the defined 'dir' path.")
 }
 
 var serverCmd = &cobra.Command{

--- a/server/app/src/state/messages.ts
+++ b/server/app/src/state/messages.ts
@@ -40,7 +40,7 @@ export interface SearchResponse extends Response {
 // DownloadResponse is received after file is downloaded from IRC and ready for
 // user download.
 export interface DownloadResponse extends Response {
-  downloadPath: string;
+  downloadPath?: string;
 }
 
 export interface BookDetail {

--- a/server/app/src/state/socketMiddleware.ts
+++ b/server/app/src/state/socketMiddleware.ts
@@ -82,7 +82,7 @@ const route = (store: Store, msg: MessageEvent<any>): void => {
         );
         return notification;
       case MessageType.DOWNLOAD:
-        downloadFile((response as DownloadResponse).downloadPath);
+        downloadFile((response as DownloadResponse)?.downloadPath);
         store.dispatch(openbooksApi.util.invalidateTags(["books"]));
         return notification;
       case MessageType.RATELIMIT:

--- a/server/app/src/state/util.ts
+++ b/server/app/src/state/util.ts
@@ -54,7 +54,9 @@ export const displayNotification = ({
   }
 };
 
-export const downloadFile = (relativeURL: string) => {
+export function downloadFile(relativeURL?: string) {
+  if (relativeURL === "" || relativeURL === undefined) return;
+
   let url = getApiURL();
   url.pathname += relativeURL;
 
@@ -64,4 +66,4 @@ export const downloadFile = (relativeURL: string) => {
   link.href = url.href;
   link.click();
   link.remove();
-};
+}

--- a/server/messages.go
+++ b/server/messages.go
@@ -108,16 +108,29 @@ func newSearchResponse(results []core.BookDetail, errors []core.ParseError) Sear
 	}
 }
 
-func newDownloadResponse(fileName string) DownloadResponse {
-	return DownloadResponse{
+func newDownloadResponse(filePath string, disableBrowserDownloads bool) DownloadResponse {
+	// If we don't want to autodownload the file, show the user the path to the file
+	// otherwise just show file name.
+	if !disableBrowserDownloads {
+		filePath = path.Base(filePath)
+	}
+
+	response := DownloadResponse{
 		StatusResponse: StatusResponse{
 			MessageType:      DOWNLOAD,
 			NotificationType: SUCCESS,
 			Title:            "Book file received.",
-			Detail:           fileName,
+			Detail:           filePath,
 		},
-		DownloadPath: path.Join("library", fileName),
 	}
+
+	// If we want to autodownload the file, add the path to the response
+	// client will not attempt autodownload if the path is empty
+	if !disableBrowserDownloads {
+		response.DownloadPath = path.Join("library", filePath)
+	}
+
+	return response
 }
 
 func newStatusResponse(notificationType NotificationType, title string) StatusResponse {

--- a/server/server.go
+++ b/server/server.go
@@ -46,17 +46,18 @@ type server struct {
 
 // Config contains settings for server
 type Config struct {
-	Log           bool
-	OpenBrowser   bool
-	Port          string
-	UserName      string
-	Persist       bool
-	DownloadDir   string
-	Basepath      string
-	Server        string
-	SearchTimeout time.Duration
-	SearchBot     string
-	Version       string
+	Log                     bool
+	OpenBrowser             bool
+	Port                    string
+	UserName                string
+	Persist                 bool
+	DownloadDir             string
+	Basepath                string
+	Server                  string
+	SearchTimeout           time.Duration
+	SearchBot               string
+	DisableBrowserDownloads bool
+	Version                 string
 }
 
 func New(config Config) *server {


### PR DESCRIPTION
When using OpenBooks to auto-import into Calibre, users don't need the file to be sent to the browser. Clicking download will save it to disk where it can be auto-imported.

Example Usage:
```
./openbooks server --no-browser-downloads --dir ~/Downloads
```