### PR TITLE
Add TLS Support for IRC communication

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,6 +14,7 @@ type Config struct {
 	Log       bool   // True if IRC messages should be logged
 	Dir       string
 	Server    string
+	EnableTLS bool
 	SearchBot string
 	Version   string
 	irc       *irc.Conn

--- a/cli/util.go
+++ b/cli/util.go
@@ -38,10 +38,11 @@ func instantiate(config *Config) {
 	fmt.Printf("Connecting to %s.", config.Server)
 	conn := irc.New(config.UserName, config.Version)
 	config.irc = conn
-	err := core.Join(conn, config.Server)
+	err := core.Join(conn, config.Server, config.EnableTLS)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	fmt.Printf("%sConnected to %s.\n", clearLine, config.Server)
 }
 

--- a/cmd/openbooks/main.go
+++ b/cmd/openbooks/main.go
@@ -34,7 +34,8 @@ var desktopConfig server.Config
 func init() {
 	desktopCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode.")
 	desktopCmd.PersistentFlags().StringVarP(&globalFlags.UserName, "name", "n", generateUserName(), "Use a name that isn't randomly generated. One word only.")
-	desktopCmd.PersistentFlags().StringVarP(&globalFlags.Server, "server", "s", "irc.irchighway.net", "IRC server to connect to.")
+	desktopCmd.PersistentFlags().StringVarP(&globalFlags.Server, "server", "s", "irc.irchighway.net:6697", "IRC server to connect to.")
+	desktopCmd.Flags().BoolVar(&serverConfig.EnableTLS, "tls", true, "Connect to server using TLS.")
 	desktopCmd.PersistentFlags().BoolVarP(&globalFlags.Log, "log", "l", false, "Save raw IRC logs for each client connection.")
 	desktopCmd.PersistentFlags().StringVar(&globalFlags.SearchBot, "searchbot", "search", "The IRC bot that handles search queries. Try 'searchook' if 'search' is down.")
 

--- a/core/irchighway.go
+++ b/core/irchighway.go
@@ -11,8 +11,8 @@ import (
 // Specific irc.irchighway.net commands
 
 // Join connects to the irc.irchighway.net server and joins the #ebooks channel
-func Join(irc *irc.Conn, url string) error {
-	err := irc.Connect(url)
+func Join(irc *irc.Conn, address string, enableTLS bool) error {
+	err := irc.Connect(address, enableTLS)
 	if err != nil {
 		return err
 	}

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -1,6 +1,7 @@
 package irc
 
 import (
+	"crypto/tls"
 	"net"
 )
 
@@ -24,8 +25,15 @@ func New(username, realname string) *Conn {
 }
 
 // Connect connects to the given server at port 6667
-func (i *Conn) Connect(address string) error {
-	conn, err := net.Dial("tcp", address+":6667")
+func (i *Conn) Connect(address string, enableTLS bool) error {
+	var conn net.Conn
+	var err error
+	if enableTLS {
+		conn, err = tls.Dial("tcp", address, &tls.Config{InsecureSkipVerify: true})
+	} else {
+		conn, err = net.Dial("tcp", address)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/server/app/src/pages/SearchPage.tsx
+++ b/server/app/src/pages/SearchPage.tsx
@@ -19,6 +19,8 @@ export default function SearchPage() {
     setShowErrors(false);
   }, [activeItem]);
 
+  const hasErrors = () =>
+    activeItem?.errors?.length && activeItem?.errors?.length > 0;
   const errorMode = () => showErrors && activeItem;
   const validInput = () => {
     if (errorMode()) {
@@ -106,7 +108,7 @@ export default function SearchPage() {
           {errorMode() ? "Download" : "Search"}
         </Button>
       </form>
-      {activeItem?.errors?.length && (
+      {hasErrors() && (
         <Button
           appearance={errorMode() ? "primary" : "minimal"}
           onClick={() => setShowErrors((show) => !show)}

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,7 @@ type Config struct {
 	DownloadDir             string
 	Basepath                string
 	Server                  string
+	EnableTLS               bool
 	SearchTimeout           time.Duration
 	SearchBot               string
 	DisableBrowserDownloads bool

--- a/server/websocket_requests.go
+++ b/server/websocket_requests.go
@@ -49,7 +49,7 @@ func (server *server) routeMessage(message Request, c *Client) {
 
 // handle ConnectionRequests and either connect to the server or do nothing
 func (c *Client) startIrcConnection(server *server) {
-	err := core.Join(c.irc, server.config.Server)
+	err := core.Join(c.irc, server.config.Server, server.config.EnableTLS)
 	if err != nil {
 		c.log.Println(err)
 		c.send <- newErrorResponse("Unable to connect to IRC server.")


### PR DESCRIPTION
## Overview
TLS allows for encrypted communication with the IRC server.

## Changes
- Add `EnableTLS bool` to config structs
- Add `--tls` CLI flag defaulted to true (_Can be set to false with `--tls=false`_)
- Move Hard-coded port to server address (_Note: [RFC 7194](https://datatracker.ietf.org/doc/html/rfc7194) does specify a default port for IRC over TLS as an alternative if hard-coding is preferred_)
- Change default port used for IRC communication
- Open socket with `crypto/tls` when TLS is enabled in config struct (_Note: Presently TLS certificate verification is disabled due to widespread use of self-signed certificates including at `irc.irchighway.net`_)
