### PR TITLE
fix: implementation of IRC `USER` command

### DIFF
--- a/irc/irc.go
+++ b/irc/irc.go
@@ -40,7 +40,7 @@ func (i *Conn) Connect(address string, enableTLS bool) error {
 
 	i.Conn = conn
 
-	user := "USER " + i.Username + " " + i.Username + " " + i.Username + " :" + i.realname + "\r\n"
+	user := "USER " + i.Username + " 0 * :" + i.realname + "\r\n"
 	nick := "NICK " + i.Username + "\r\n"
 
 	i.Write([]byte(user))


### PR DESCRIPTION
Fix of IRC `USER` command according to [RFC2812](https://datatracker.ietf.org/doc/html/rfc2812#section-3.1.3), see issue #107.
Second parameter is set to 0 by default. If required, the functionality to set the user mode at initial connection can be added. Available modes are ([see user mode explanation](https://datatracker.ietf.org/doc/html/rfc2812#section-3.1.5)):
- i - marks a users as invisible
- w - user receives wallops