### PR TITLE
Use ASCIISet

### DIFF
--- a/core/server_parser.go
+++ b/core/server_parser.go
@@ -3,15 +3,11 @@ package core
 import (
 	"sort"
 	"strings"
+
+	"github.com/elliotwutingfeng/asciiset"
 )
 
-var prefixes = map[byte]struct{}{
-	'~': {},
-	'&': {},
-	'@': {},
-	'%': {},
-	'+': {},
-}
+var prefixes, _ = asciiset.MakeASCIISet("~&@%+")
 
 type IrcServers struct {
 	ElevatedUsers []string `json:"elevatedUsers"`
@@ -30,7 +26,7 @@ func ParseServers(rawString string) IrcServers {
 
 	for _, name := range allServers {
 		if len(name) > 1 {
-			if _, exists := prefixes[name[0]]; exists {
+			if exists := prefixes.Contains(name[0]); exists {
 				servers.ElevatedUsers = append(servers.ElevatedUsers, name[1:])
 			} else {
 				servers.RegularUsers = append(servers.RegularUsers, name)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/elliotwutingfeng/asciiset v0.0.0-20230602005253-7f88bc28b13f
 	github.com/inkeliz/gowebview v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602005253-7f88bc28b13f h1:2zrq6AHwG5HdTmNunOU3tRNPQ0F+R9W8mIxgSJzGwkE=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602005253-7f88bc28b13f/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=


### PR DESCRIPTION
Proposing use of `ASCIISet` instead of `map[byte]struct{}`.

`ASCIISet` is a zero-dependency library for sets of ASCII characters with [28 times faster lookup speed](https://github.com/elliotwutingfeng/asciiset#results) than `map[byte]struct{}`.