### PR TITLE
feat: persist irc connections between websocket disconnects

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,11 +12,19 @@
   "remoteUser": "root",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {},
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "customizations": {
     "vscode": {
-      "extensions": ["golang.go", "heybourn.headwind", "esbenp.prettier-vscode", "bradlc.vscode-tailwindcss", "ms-vscode.makefile-tools", "redhat.vscode-yaml"]
+      "extensions": [
+        "golang.go",
+        "heybourn.headwind",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.makefile-tools",
+        "redhat.vscode-yaml"
+      ]
     }
   }
 }

--- a/server/client.go
+++ b/server/client.go
@@ -60,7 +60,6 @@ type Client struct {
 // reads from this goroutine.
 func (server *server) readPump(c *Client) {
 	defer func() {
-		c.irc.Disconnect()
 		c.conn.Close()
 		server.unregister <- c
 	}()

--- a/server/routes.go
+++ b/server/routes.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/evan-buss/openbooks/irc"
 	"io/fs"
 	"log"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/evan-buss/openbooks/irc"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -90,9 +91,6 @@ func (server *server) serveWs() http.HandlerFunc {
 		client.log.Println("New client created.")
 
 		server.register <- client
-
-		go server.writePump(client)
-		go server.readPump(client)
 	}
 }
 


### PR DESCRIPTION
- currently, when the websocket connection is dropped, the irc connection is closed immediately. this change makes it so that after the websocket connection closed, the user has 3 minutes to reconnect before we close the irc connection.
- the 3 minute 'self-destruct' is only triggered when the websocket is disconnected and is disabled once there is another connection
- this should help with certain devices (such as iPad) where switching apps / tabs seems to close the websocket. i believe that the IRC server is sensitive to clients connecting/disconnecting too often and will ban users.