### PR TITLE
fix: load active item from storage if present

### DIFF
--- a/server/app/src/state/historySlice.ts
+++ b/server/app/src/state/historySlice.ts
@@ -24,8 +24,16 @@ const loadState = (): HistoryItem[] => {
   }
 };
 
+const loadActiveState = (): number | undefined => {
+  try {
+    return JSON.parse(localStorage.getItem("active")!);
+  } catch (err) {
+    return undefined;
+  }
+};
+
 const initialState: HistoryState = {
-  active: undefined,
+  active: loadActiveState(),
   items: loadState()
 };
 


### PR DESCRIPTION
We were doing this in the old redux model, but forgot to implement since we moved the "active" state to the historySlice rather than the stateSlice for easier manipulation and removing thunks