### PR TITLE
fix: optimistic update history entry

### DIFF
--- a/server/app/src/state/historySlice.ts
+++ b/server/app/src/state/historySlice.ts
@@ -59,12 +59,19 @@ export const historySlice = createSlice({
     }
   },
   extraReducers: (builder) => {
-    builder.addMatcher(api.endpoints.search.matchFulfilled, (state, action) => {
+    // Optimistic updates for search requests as we might get back
+    // the search results before the HTTP request "completes".
+    builder.addMatcher(api.endpoints.search.matchPending, (state, action) => {
       const timestamp = new Date().getTime();
       const query = action.meta.arg.originalArgs;
 
       state.active = timestamp;
       state.items = [{ query, timestamp }, ...state.items].slice(0, 16);
+    });
+    // If the request actually fails, remove the optimistic update
+    builder.addMatcher(api.endpoints.search.matchRejected, (state) => {
+      state.active = undefined;
+      state.items.shift();
     });
   }
 });


### PR DESCRIPTION
If the IRC server processes the request fast enough we were setting the search results faster than we could create a new history entry for them. This resulted in writing to the previous history entry and the latest entry stuck in loading state.